### PR TITLE
fix(ozon): при set result=false сверять exemplar/status — passed счит…

### DIFF
--- a/src/posting/dto/exemplar.status.dto.ts
+++ b/src/posting/dto/exemplar.status.dto.ts
@@ -1,4 +1,8 @@
-export type ExemplarShipStatus = 'ship_available' | 'ship_not_available' | 'validation_in_process';
+export type ExemplarShipStatus =
+    | 'ship_available'
+    | 'ship_not_available'
+    | 'validation_in_process'
+    | 'update_available';
 
 export interface ExemplarStatusMarkDto {
     mark: string;

--- a/src/posting/posting.service.spec.ts
+++ b/src/posting/posting.service.spec.ts
@@ -434,6 +434,87 @@ describe('PostingService', () => {
             });
         });
 
+        it('set result=false, но exemplar/status все passed → ok=true (идемпотентно)', async () => {
+            getAttachedMarkCodesByScode.mockResolvedValueOnce([
+                { ki: 'KI-1', goodscode: '531557', realpricecode: 1, quantity: 1 },
+            ]);
+            getKmFullByKi.mockResolvedValueOnce('01FULL');
+            ozonApiMethod
+                .mockResolvedValueOnce({
+                    posting_number: 'P-1',
+                    multi_box_qty: 1,
+                    products: [
+                        {
+                            product_id: 999,
+                            quantity: 1,
+                            is_mandatory_mark_needed: true,
+                            exemplars: [{ exemplar_id: 111, marks: [] }],
+                        },
+                    ],
+                })
+                .mockResolvedValueOnce({
+                    result: { products: [{ offer_id: '531557', sku: 999 }] },
+                })
+                .mockResolvedValueOnce({ result: false })
+                .mockResolvedValueOnce({
+                    posting_number: 'P-1',
+                    status: 'update_available',
+                    products: [
+                        {
+                            product_id: 999,
+                            exemplars: [{ exemplar_id: 111, marks: [{ check_status: 'passed' }] }],
+                        },
+                    ],
+                });
+            const res = await service.submitFbsMarkCodes(invoice);
+            expect(res).toEqual({ ok: true });
+            expect(ozonApiMethod).toHaveBeenNthCalledWith(
+                4,
+                '/v5/fbs/posting/product/exemplar/status',
+                { posting_number: 'P-1' },
+            );
+        });
+
+        it('set result=false и exemplar/status не passed → ok=false с причиной', async () => {
+            getAttachedMarkCodesByScode.mockResolvedValueOnce([
+                { ki: 'KI-1', goodscode: '531557', realpricecode: 1, quantity: 1 },
+            ]);
+            getKmFullByKi.mockResolvedValueOnce('01FULL');
+            ozonApiMethod
+                .mockResolvedValueOnce({
+                    posting_number: 'P-1',
+                    multi_box_qty: 1,
+                    products: [
+                        {
+                            product_id: 999,
+                            quantity: 1,
+                            is_mandatory_mark_needed: true,
+                            exemplars: [{ exemplar_id: 111, marks: [] }],
+                        },
+                    ],
+                })
+                .mockResolvedValueOnce({
+                    result: { products: [{ offer_id: '531557', sku: 999 }] },
+                })
+                .mockResolvedValueOnce({ result: false })
+                .mockResolvedValueOnce({
+                    posting_number: 'P-1',
+                    status: 'ship_not_available',
+                    products: [
+                        {
+                            product_id: 999,
+                            exemplars: [{ exemplar_id: 111, marks: [{ check_status: 'failed' }] }],
+                        },
+                    ],
+                });
+            const res = await service.submitFbsMarkCodes(invoice);
+            expect(res.ok).toBe(false);
+            expect(res.failed).toContainEqual({
+                ki: '*',
+                reason: 'setExemplars result=false; status=ship_not_available',
+            });
+        });
+
         it('dry-run для FBS-MIG-* в development не вызывает Ozon', async () => {
             nodeEnv = 'development';
             getAttachedMarkCodesByScode.mockResolvedValueOnce([

--- a/src/posting/posting.service.ts
+++ b/src/posting/posting.service.ts
@@ -338,15 +338,36 @@ export class PostingService implements IOrderable, ISuppliable, IMarkSubmittable
             return { ok: false, failed };
         }
 
-        const setResp = await this.setExemplars({
+        const setReq = {
             posting_number: postingNumber,
             multi_box_qty: exResp.multi_box_qty || 1,
             products: setProducts,
-        });
+        };
+        this.logger.log(`[km ${postingNumber}] set req=${JSON.stringify(setReq)}`);
+        const setResp = await this.setExemplars(setReq);
+        this.logger.log(`[km ${postingNumber}] set resp=${JSON.stringify(setResp)}`);
         if (!setResp?.result) {
+            // Озон вернул false — не верим на слово, спрашиваем фактическое состояние.
+            const status = await this.getExemplarStatus(postingNumber);
+            const allPassed =
+                (status?.products?.length ?? 0) > 0 &&
+                status.products.every((p) =>
+                    p.exemplars?.every((e) => e.marks?.every((m) => m.check_status === 'passed')),
+                );
+            this.logger.warn(
+                `[km ${postingNumber}] set=false; overall=${status?.status}; allPassed=${allPassed}`,
+            );
+            if (allPassed) {
+                // Экземпляры уже стоят и прошли проверку — коды фактически на месте.
+                // Считаем успехом, чтобы крон перестал ретраить.
+                return { ok: true };
+            }
             return {
                 ok: false,
-                failed: [...failed, { ki: '*', reason: 'setExemplars result=false' }],
+                failed: [
+                    ...failed,
+                    { ki: '*', reason: `setExemplars result=false; status=${status?.status}` },
+                ],
             };
         }
 


### PR DESCRIPTION
…ать успехом

Озон на exemplar/set может вернуть result=false, когда экземпляры уже выставлены (ручной ввод/ранее). Теперь дёргаем getExemplarStatus: если все марки check_status=passed — возвращаем ok:true, крон перестаёт ретраить. Логируем сырые set req/resp. В union статуса добавлен update_available.