### PR TITLE
fix(tnved-sync): «ок» = вариант «МАРКИРОВКА РФ» + чекбокс, а не тольк…

### DIFF
--- a/src/tnved-sync/tnved-sync.service.spec.ts
+++ b/src/tnved-sync/tnved-sync.service.spec.ts
@@ -17,10 +17,19 @@ describe('TnvedSyncService', () => {
     const updateAttributes = jest.fn();
     const productService = { list, getProductAttributes, searchCategoryAttributeValues, updateAttributes };
 
+    // id значений словаря ТНВЭД 8504409100 в категории
+    const MARK_ID = 972997562; // «8504409100 - МАРКИРОВКА РФ»
+    const PLAIN_ID = 971399915; // «8504409100 - Преобразователи» (без маркировки)
+    const MARK_VALUES = [
+        { id: MARK_ID, value: '8504409100 - МАРКИРОВКА РФ - Преобразователи' },
+        { id: PLAIN_ID, value: '8504409100 - Преобразователи' },
+    ];
+
     beforeEach(async () => {
         [query, commit, rollback, list, getProductAttributes, searchCategoryAttributeValues, updateAttributes].forEach(
             (m) => m.mockReset(),
         );
+        searchCategoryAttributeValues.mockResolvedValue(MARK_VALUES);
         const moduleRef: TestingModule = await Test.createTestingModule({
             providers: [
                 TnvedSyncService,
@@ -32,67 +41,78 @@ describe('TnvedSyncService', () => {
         service = moduleRef.get(TnvedSyncService);
     });
 
-    const productAttrs = (offer: string, tnved: string | null) => ({
+    // карточка Озона: code — цифры ТНВЭД, dictId — id варианта словаря, markOn — чекбокс «Нужен код маркировки»
+    const card = (offer: string, d: { code?: string | null; dictId?: number | null; markOn?: boolean } = {}) => ({
         offer_id: offer,
         id: 999,
         name: `PROD-${offer}`,
         description_category_id: 42872319,
         type_id: 99309,
-        attributes: tnved ? [{ id: 22232, values: [{ value: `${tnved} - Что-то там` }] }] : [],
+        attributes: [
+            { id: 22232, values: [{ dictionary_value_id: d.dictId ?? null, value: `${d.code ?? ''} - x` }] },
+            { id: 23536, values: [{ value: d.markOn ? 'true' : 'false' }] },
+        ],
     });
 
-    const MARK = [
-        { id: 972997562, value: '8504409100 - МАРКИРОВКА РФ - Преобразователи' },
-        { id: 971399915, value: '8504409100 - Преобразователи' },
-    ];
-
-    // Озон-каталог: список offer'ов + карта offer -> текущий ТНВЭД карточки
-    const ozonCatalog = (offers: string[], attrs: Record<string, string | null>) => {
+    const ozonCatalog = (offers: string[], cards: Record<string, Parameters<typeof card>[1]>) => {
         list.mockResolvedValue({ result: { items: offers.map((o) => ({ offer_id: o })), last_id: '' } });
-        getProductAttributes.mockImplementation((o: string) =>
-            Promise.resolve(o in attrs ? productAttrs(o, attrs[o]) : null),
-        );
+        getProductAttributes.mockImplementation((o: string) => Promise.resolve(o in cards ? card(o, cards[o]) : null));
     };
 
-    it('ТНВЭД отличается → toFix с dictValueId «МАРКИРОВКА РФ», без записи (dry-run)', async () => {
-        query.mockResolvedValueOnce([{ GOODSCODE: 568651, TNVED: '8504409100' }]);
-        ozonCatalog(['568651'], { '568651': '8504408500' });
-        searchCategoryAttributeValues.mockResolvedValue(MARK);
+    it('правильный код, но ПЛОСКИЙ вариант + чекбокс выкл → toFix (кейс со скрина HDR-100-24)', async () => {
+        query.mockResolvedValueOnce([{ GOODSCODE: 568615, TNVED: '8504409100' }]);
+        ozonCatalog(['568615'], { '568615': { code: '8504409100', dictId: PLAIN_ID, markOn: false } });
 
         const rep = await service.sync({ apply: false });
 
-        expect(rep.checkedGoods).toBe(1);
-        expect(rep.checkedOffers).toBe(1);
-        expect(rep.toFix[0]).toMatchObject({
-            offer: '568651',
-            goodscode: '568651',
-            ozon: '8504408500',
-            base: '8504409100',
-            dictValueId: 972997562,
-        });
-        expect(updateAttributes).not.toHaveBeenCalled();
+        expect(rep.alreadyOk).toBe(0);
+        expect(rep.toFix).toHaveLength(1);
+        expect(rep.toFix[0]).toMatchObject({ offer: '568615', dictValueId: MARK_ID });
+        expect(rep.toFix[0].reason).toContain('МАРКИРОВКА РФ');
+        expect(rep.toFix[0].reason).toContain('чекбокс');
     });
 
-    it('суффиксные варианты (531557 и 531557-10) — правятся ОБА', async () => {
-        query.mockResolvedValueOnce([{ GOODSCODE: 531557, TNVED: '8504409100' }]);
-        ozonCatalog(['531557', '531557-10', '999999'], { '531557': '8504408500', '531557-10': null });
-        searchCategoryAttributeValues.mockResolvedValue(MARK);
-
-        const rep = await service.sync({ apply: false });
-
-        expect(rep.checkedOffers).toBe(2);
-        expect(rep.toFix.map((f) => f.offer).sort()).toEqual(['531557', '531557-10']);
-        expect(rep.notFoundOnOzon).toHaveLength(0);
-    });
-
-    it('ТНВЭД совпадает → alreadyOk', async () => {
+    it('нужный вариант «МАРКИРОВКА РФ» + чекбокс вкл → alreadyOk', async () => {
         query.mockResolvedValueOnce([{ GOODSCODE: 111, TNVED: '8504409100' }]);
-        ozonCatalog(['111'], { '111': '8504409100' });
+        ozonCatalog(['111'], { '111': { code: '8504409100', dictId: MARK_ID, markOn: true } });
 
         const rep = await service.sync({ apply: false });
 
         expect(rep.alreadyOk).toBe(1);
         expect(rep.toFix).toHaveLength(0);
+    });
+
+    it('нужный вариант, но чекбокс ВЫКЛ → toFix', async () => {
+        query.mockResolvedValueOnce([{ GOODSCODE: 112, TNVED: '8504409100' }]);
+        ozonCatalog(['112'], { '112': { code: '8504409100', dictId: MARK_ID, markOn: false } });
+
+        const rep = await service.sync({ apply: false });
+
+        expect(rep.toFix).toHaveLength(1);
+        expect(rep.toFix[0].reason).toContain('чекбокс');
+    });
+
+    it('другой ТНВЭД → toFix', async () => {
+        query.mockResolvedValueOnce([{ GOODSCODE: 568651, TNVED: '8504409100' }]);
+        ozonCatalog(['568651'], { '568651': { code: '8504408500', dictId: 971399914, markOn: false } });
+
+        const rep = await service.sync({ apply: false });
+
+        expect(rep.toFix[0]).toMatchObject({ offer: '568651', ozon: '8504408500', base: '8504409100', dictValueId: MARK_ID });
+        expect(updateAttributes).not.toHaveBeenCalled();
+    });
+
+    it('суффиксные варианты (531557 и 531557-10) — оба в toFix', async () => {
+        query.mockResolvedValueOnce([{ GOODSCODE: 531557, TNVED: '8504409100' }]);
+        ozonCatalog(['531557', '531557-10', '999999'], {
+            '531557': { code: '8504408500', dictId: 971399914, markOn: false },
+            '531557-10': { code: null, dictId: null, markOn: false },
+        });
+
+        const rep = await service.sync({ apply: false });
+
+        expect(rep.checkedOffers).toBe(2);
+        expect(rep.toFix.map((f) => f.offer).sort()).toEqual(['531557', '531557-10']);
     });
 
     it('на Озоне нет ни одной карточки товара → notFoundOnOzon', async () => {
@@ -107,7 +127,7 @@ describe('TnvedSyncService', () => {
 
     it('нет варианта «МАРКИРОВКА РФ» → ambiguous', async () => {
         query.mockResolvedValueOnce([{ GOODSCODE: 333, TNVED: '8541410008' }]);
-        ozonCatalog(['333'], { '333': '8504408500' });
+        ozonCatalog(['333'], { '333': { code: '8504408500', dictId: 1, markOn: false } });
         searchCategoryAttributeValues.mockResolvedValue([{ id: 1, value: '8541410008 - Светодиоды (без маркировки)' }]);
 
         const rep = await service.sync({ apply: false });
@@ -116,19 +136,18 @@ describe('TnvedSyncService', () => {
         expect(rep.ambiguous[0].offer).toBe('333');
     });
 
-    it('apply=true → зовёт updateAttributes с ТНВЭД+маркировкой и возвращает task_id', async () => {
-        query.mockResolvedValueOnce([{ GOODSCODE: 568651, TNVED: '8504409100' }]);
-        ozonCatalog(['568651'], { '568651': '8504408500' });
-        searchCategoryAttributeValues.mockResolvedValue(MARK);
+    it('apply=true → updateAttributes с вариантом МАРКИРОВКА РФ + чекбокс, возвращает task_id', async () => {
+        query.mockResolvedValueOnce([{ GOODSCODE: 568615, TNVED: '8504409100' }]);
+        ozonCatalog(['568615'], { '568615': { code: '8504409100', dictId: PLAIN_ID, markOn: false } });
         updateAttributes.mockResolvedValue([{ task_id: 5221013431 }]);
 
         const rep = await service.sync({ apply: true });
 
         expect(rep.toFix[0].taskId).toBe(5221013431);
         expect(updateAttributes).toHaveBeenCalledWith({
-            offer_ids: ['568651'],
+            offer_ids: ['568615'],
             attributes: [
-                { complex_id: 0, id: 22232, values: [{ dictionary_value_id: 972997562 }] },
+                { complex_id: 0, id: 22232, values: [{ dictionary_value_id: MARK_ID }] },
                 { complex_id: 0, id: 23536, values: [{ value: 'true' }] },
             ],
         });

--- a/src/tnved-sync/tnved-sync.service.ts
+++ b/src/tnved-sync/tnved-sync.service.ts
@@ -17,6 +17,7 @@ export interface TnvedFixItem {
     ozon: string | null; // текущий ТНВЭД на Озоне
     base: string; // наш ТНВЭД из базы
     dictValueId?: number; // dictionary_value_id варианта «МАРКИРОВКА РФ»
+    reason: string; // почему считается требующим правки
     action: string;
     taskId?: number; // после apply
     error?: string; // после apply
@@ -114,22 +115,22 @@ export class TnvedSyncService {
 
         const cat = prod.description_category_id;
         const type = prod.type_id;
-        const attr = (prod.attributes || []).find((a: any) => a.id === this.tnvedAttrId);
-        const currentVal: string = attr?.values?.[0]?.value ?? '';
+        const attrs: any[] = prod.attributes || [];
+        const tnvedAttr = attrs.find((a) => a.id === this.tnvedAttrId);
+        const currentDictId: number | null = tnvedAttr?.values?.[0]?.dictionary_value_id ?? null;
+        const currentVal: string = tnvedAttr?.values?.[0]?.value ?? '';
         const currentCode = (/^\s*(\d{4,10})/.exec(currentVal) || [])[1] ?? null;
+        const markAttr = attrs.find((a) => a.id === this.markAttrId);
+        const markOn = String(markAttr?.values?.[0]?.value ?? '').toLowerCase() === 'true';
 
-        if (currentCode === tnved) {
-            report.alreadyOk++;
-            return;
-        }
-
+        // Целевой вариант «МАРКИРОВКА РФ» нашего ТНВЭД в категории карточки
         const key = `${cat}:${type}:${tnved}`;
-        let dictId = dictCache.get(key);
-        if (dictId === undefined) {
-            dictId = await this.resolveMarkDictValue(cat, type, tnved);
-            dictCache.set(key, dictId);
+        let targetDictId = dictCache.get(key);
+        if (targetDictId === undefined) {
+            targetDictId = await this.resolveMarkDictValue(cat, type, tnved);
+            dictCache.set(key, targetDictId);
         }
-        if (!dictId) {
+        if (!targetDictId) {
             report.ambiguous.push({
                 offer: offerId,
                 reason: `нет варианта «${MARK_LABEL}» для ТНВЭД ${tnved} (cat ${cat}/${type})`,
@@ -137,19 +138,32 @@ export class TnvedSyncService {
             return;
         }
 
+        // ОК = ровно нужный dictionary_value_id (вариант с маркировкой) И включённый чекбокс маркировки.
+        // Совпадения одних лишь цифр ТНВЭД мало: плоский вариант без «МАРКИРОВКА РФ» / выключенный чекбокс — это НЕ ок.
+        if (currentDictId === targetDictId && markOn) {
+            report.alreadyOk++;
+            return;
+        }
+
+        const reasons: string[] = [];
+        if (currentCode !== tnved) reasons.push(`ТНВЭД ${currentCode ?? '—'}→${tnved}`);
+        else if (currentDictId !== targetDictId) reasons.push(`вариант без «${MARK_LABEL}»`);
+        if (!markOn) reasons.push('чекбокс маркировки выкл');
+
         const fix: TnvedFixItem = {
             offer: offerId,
             goodscode,
             name: prod.name,
             ozon: currentCode,
             base: tnved,
-            dictValueId: dictId,
+            dictValueId: targetDictId,
+            reason: reasons.join('; '),
             action: `set ${tnved} (${MARK_LABEL}) + Нужен код маркировки`,
         };
 
         if (apply) {
             try {
-                fix.taskId = await this.applyFix(offerId, dictId);
+                fix.taskId = await this.applyFix(offerId, targetDictId);
             } catch (e) {
                 fix.error = e?.message ?? String(e);
             }


### PR DESCRIPTION
…о цифры ТНВЭД

Сравнивали лишь цифры кода → карточка с правильным кодом, но в ПЛОСКОМ варианте (без «МАРКИРОВКА РФ») и с выключенным «Нужен код маркировки» ложно считалась alreadyOk. Теперь ок только если dictionary_value_id == целевому (вариант с маркировкой) И чекбокс включён; иначе toFix c reason (другой ТНВЭД / вариант без маркировки / чекбокс выкл).