### PR TITLE
fix(wb): убрать несуществующий GET /orders/{id}/meta, детектить NotOk…

### DIFF
--- a/src/wb.order/wb.order.service.spec.ts
+++ b/src/wb.order/wb.order.service.spec.ts
@@ -866,40 +866,60 @@ describe('WbOrderService', () => {
             expect(method).not.toHaveBeenCalled();
         });
 
-        it('meta без sgtin → skipped', async () => {
+        it('не делает GET /meta (его нет в API v3), сразу PUT sgtin', async () => {
             getAttachedMarkCodesByScode.mockResolvedValueOnce([
                 { ki: 'KI-1', goodscode: '531557', realpricecode: 1 },
             ]);
-            method.mockResolvedValueOnce({ meta: {}, requiredMeta: [], optionalMeta: ['gtin'] });
+            getKmFullByKi.mockResolvedValueOnce('01FULL-1');
+            method.mockResolvedValueOnce({});
+
             const res = await service.submitFbsMarkCodes(invoice);
-            expect(res).toEqual({ ok: true, skipped: 'no sgtin required' });
+
+            expect(res).toEqual({ ok: true });
             expect(method).toHaveBeenCalledTimes(1);
-            expect(method).toHaveBeenCalledWith('/api/v3/orders/592715/meta', 'get', {});
+            expect(method).toHaveBeenCalledWith('/api/v3/orders/592715/meta/sgtin', 'put', {
+                sgtins: ['01FULL-1'],
+            });
         });
 
-        it('happy path: meta(requires sgtin) → setOrderKiz', async () => {
+        it('happy path: attached КМ → setOrderKiz (PUT sgtin)', async () => {
             getAttachedMarkCodesByScode.mockResolvedValueOnce([
                 { ki: 'KI-1', goodscode: '531557', realpricecode: 1 },
                 { ki: 'KI-2', goodscode: '531557', realpricecode: 1 },
             ]);
-            method.mockResolvedValueOnce({ meta: {}, requiredMeta: ['sgtin'] });
             getKmFullByKi.mockResolvedValueOnce('01FULL-1').mockResolvedValueOnce('01FULL-2');
             method.mockResolvedValueOnce({});
 
             const res = await service.submitFbsMarkCodes(invoice);
 
             expect(res).toEqual({ ok: true });
-            expect(method).toHaveBeenNthCalledWith(2, '/api/v3/orders/592715/meta/sgtin', 'put', {
+            expect(method).toHaveBeenCalledWith('/api/v3/orders/592715/meta/sgtin', 'put', {
                 sgtins: ['01FULL-1', '01FULL-2'],
             });
         });
 
-        it('часть KM_FULL пуста → ok=true с failed для пустых', async () => {
+        it('PUT вернул NotOk → ok=false без skipRetry (крон повторит)', async () => {
+            getAttachedMarkCodesByScode.mockResolvedValueOnce([
+                { ki: 'KI-1', goodscode: '531557', realpricecode: 1 },
+            ]);
+            getKmFullByKi.mockResolvedValueOnce('01FULL-1');
+            method.mockResolvedValueOnce({
+                status: 'NotOk',
+                error: { status: 405, message: 'method not allowed' },
+            });
+
+            const res = await service.submitFbsMarkCodes(invoice);
+
+            expect(res.ok).toBe(false);
+            expect(res.skipRetry).toBeUndefined();
+            expect(res.failed?.[0]?.reason).toContain('405');
+        });
+
+        it('часть KM_FULL пуста → ok=false с failed для пустых', async () => {
             getAttachedMarkCodesByScode.mockResolvedValueOnce([
                 { ki: 'KI-1', goodscode: '531557', realpricecode: 1 },
                 { ki: 'KI-2', goodscode: '531557', realpricecode: 1 },
             ]);
-            method.mockResolvedValueOnce({ meta: {}, optionalMeta: ['sgtin'] });
             getKmFullByKi.mockResolvedValueOnce('01FULL-1').mockResolvedValueOnce(null);
             method.mockResolvedValueOnce({});
 
@@ -907,33 +927,31 @@ describe('WbOrderService', () => {
 
             expect(res.ok).toBe(false);
             expect(res.failed).toEqual([{ ki: 'KI-2', reason: 'KM_FULL пуст' }]);
-            expect(method).toHaveBeenNthCalledWith(2, '/api/v3/orders/592715/meta/sgtin', 'put', {
+            expect(method).toHaveBeenCalledWith('/api/v3/orders/592715/meta/sgtin', 'put', {
                 sgtins: ['01FULL-1'],
             });
         });
 
-        it('все KM_FULL пусты → ok=false, setOrderKiz не вызывается', async () => {
+        it('все KM_FULL пусты → ok=false, PUT не вызывается', async () => {
             getAttachedMarkCodesByScode.mockResolvedValueOnce([
                 { ki: 'KI-1', goodscode: '531557', realpricecode: 1 },
             ]);
-            method.mockResolvedValueOnce({ meta: {}, requiredMeta: ['sgtin'] });
             getKmFullByKi.mockResolvedValueOnce(null);
 
             const res = await service.submitFbsMarkCodes(invoice);
 
             expect(res.ok).toBe(false);
             expect(res.failed).toEqual([{ ki: 'KI-1', reason: 'KM_FULL пуст' }]);
-            expect(method).toHaveBeenCalledTimes(1);
+            expect(method).not.toHaveBeenCalled();
         });
 
-        it('>100 КМ → skipRetry=true, без вызова setOrderKiz', async () => {
+        it('>100 КМ → skipRetry=true, PUT не вызывается', async () => {
             const many = Array.from({ length: 101 }, (_, i) => ({
                 ki: `KI-${i}`,
                 goodscode: '531557',
                 realpricecode: 1,
             }));
             getAttachedMarkCodesByScode.mockResolvedValueOnce(many);
-            method.mockResolvedValueOnce({ meta: {}, requiredMeta: ['sgtin'] });
             getKmFullByKi.mockImplementation((ki: string) => Promise.resolve(`01FULL-${ki}`));
 
             const res = await service.submitFbsMarkCodes(invoice);
@@ -941,7 +959,7 @@ describe('WbOrderService', () => {
             expect(res.ok).toBe(false);
             expect(res.skipRetry).toBe(true);
             expect(res.failed?.[0]?.reason).toContain('>100 КМ');
-            expect(method).toHaveBeenCalledTimes(1);
+            expect(method).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/wb.order/wb.order.service.ts
+++ b/src/wb.order/wb.order.service.ts
@@ -29,7 +29,6 @@ import { WbInvoiceQueryDto } from '../order/dto/wb-invoice-query.dto';
 import { WbInvoiceSridQueryDto } from '../order/dto/wb-invoice-srid-query.dto';
 import { RateLimit, setRateLimitBlocked } from '../helpers/decorators/rate-limit.decorator';
 import { IMarkSubmittable, SubmitFailureDto, SubmitResultDto } from '../interfaces/IMarkSubmittable';
-import { WbOrderMetaDto } from './dto/wb.order.meta.dto';
 import { WbOrderSetKizRequestDto } from './dto/wb.order.set-kiz.dto';
 import { FboMarkMigrationService } from '../posting.fbo/fbo-mark-migration.service';
 import { ProcessedCacheService } from '../processed-cache/processed-cache.service';
@@ -465,13 +464,9 @@ export class WbOrderService implements IOrderable, IMarkSubmittable {
         return context.invoice || null;
     }
 
-    async getOrderMeta(orderId: number): Promise<WbOrderMetaDto> {
-        return this.api.method(`/api/v3/orders/${orderId}/meta`, 'get', {});
-    }
-
-    async setOrderKiz(orderId: number, sgtins: string[]): Promise<void> {
+    async setOrderKiz(orderId: number, sgtins: string[]): Promise<any> {
         const body: WbOrderSetKizRequestDto = { sgtins };
-        await this.api.method(`/api/v3/orders/${orderId}/meta/sgtin`, 'put', body);
+        return this.api.method(`/api/v3/orders/${orderId}/meta/sgtin`, 'put', body);
     }
 
     async submitFbsMarkCodes(invoice: InvoiceDto): Promise<SubmitResultDto> {
@@ -487,13 +482,10 @@ export class WbOrderService implements IOrderable, IMarkSubmittable {
             };
         }
 
-        const meta = await this.getOrderMeta(orderId);
-        const needsSgtin =
-            meta?.requiredMeta?.includes('sgtin') || meta?.optionalMeta?.includes('sgtin');
-        if (!needsSgtin) {
-            return { ok: true, skipped: 'no sgtin required' };
-        }
-
+        // Per-order GET /orders/{id}/meta в API v3 нет (WB отвечает 405, Allow: DELETE):
+        // requiredMeta отдаётся только в списке /orders/new. Но сюда мы попадаем лишь при
+        // attached.length > 0 — на заказе есть привязанные КМ, значит товар маркируемый и
+        // sgtin требуется. Поэтому сразу привязываем КИЗ через PUT /orders/{id}/meta/sgtin.
         const sgtins: string[] = [];
         const failed: SubmitFailureDto[] = [];
         for (const a of attached) {
@@ -511,7 +503,23 @@ export class WbOrderService implements IOrderable, IMarkSubmittable {
             };
         }
 
-        await this.setOrderKiz(orderId, sgtins);
+        // WbApiService на ошибке не бросает, а возвращает { status:'NotOk', error }.
+        // Ловим это явно, иначе неотправленный КИЗ (405 и т.п.) уедет как ok:true,
+        // крон закэширует заказ отправленным и повтора не будет.
+        const resp = await this.setOrderKiz(orderId, sgtins);
+        if (resp?.status === 'NotOk' || resp?.error) {
+            const err = resp?.error ?? {};
+            return {
+                ok: false,
+                failed: [
+                    ...failed,
+                    {
+                        ki: '*',
+                        reason: `WB meta/sgtin: ${err.status ?? ''} ${err.message ?? err.service_message ?? ''}`.trim(),
+                    },
+                ],
+            };
+        }
 
         return failed.length === 0 ? { ok: true } : { ok: false, failed };
     }


### PR DESCRIPTION
… на PUT sgtin — крон ретраит вместо ложного успеха