### PR TITLE
fix(ozon-fbs): количественный код-упаковка проходит передачу — 1 код …

### DIFF
--- a/src/posting/commands/build-exemplars-payload.command.ts
+++ b/src/posting/commands/build-exemplars-payload.command.ts
@@ -63,21 +63,14 @@ export class BuildExemplarsPayloadCommand implements ICommandAsync<IFbsSubmitCon
 
             if (group.length > 0) {
                 // === СТРОКА СО ЗНАКОМ ===
-                const multi = group.find((g) => g.quantity > 1);
-                if (multi) {
-                    ctx.failed.push({
-                        ki: multi.ki,
-                        reason:
-                            `количественный КМ (x${multi.quantity}): Ozon FBS требует штучные экземпляры — ` +
-                            'поделите код (MARKCODE_SPLIT / деление в ЛК ЧЗ)',
-                    });
-                    continue;
-                }
-                const qtySum = group.reduce((s, g) => s + g.quantity, 0);
-                if (qtySum !== exProduct.quantity) {
+                // Один привязанный код = один экземпляр Ozon: штучный код (QUANTITY=1)
+                // ИЛИ код-упаковка (QUANTITY=N) — Ozon принимает «один код с упаковки».
+                // Сверяем ЧИСЛО КОДОВ с числом экземпляров, а НЕ сумму штук: у товара-упаковки
+                // 1 юнит Ozon = N наших штук = 1 код (напр. арт. …-3: 2 юнита = 6 шт = 2 кода).
+                if (group.length !== exProduct.quantity) {
                     ctx.failed.push({
                         ki: '*',
-                        reason: `product_id ${exProduct.product_id}: КМ на ${qtySum} шт, ожидается ${exProduct.quantity}`,
+                        reason: `product_id ${exProduct.product_id}: привязано кодов ${group.length}, Ozon ждёт экземпляров ${exProduct.quantity}`,
                     });
                     continue;
                 }

--- a/src/posting/posting.service.spec.ts
+++ b/src/posting/posting.service.spec.ts
@@ -521,11 +521,12 @@ describe('PostingService', () => {
             expect(res.goToOzon).toBe(true);
         });
 
-        it('количественный КМ (quantity>1) → failed с подсказкой про деление', async () => {
+        it('код-упаковка (quantity>1) на 1 экземпляр → успех, код уходит как есть', async () => {
+            // Арт. …-3: Ozon продаёт 1 юнит (упаковку 3 шт), экземпляр один, код один количественный.
             getAttachedMarkCodesByScode.mockResolvedValueOnce([
-                { ki: 'KI-50', goodscode: '531557', realpricecode: 1, quantity: 50 },
+                { ki: 'KI-PACK', goodscode: '531557', realpricecode: 1, quantity: 3 },
             ]);
-            getKmFullByKi.mockResolvedValueOnce('01FULL-MARK-50');
+            getKmFullByKi.mockResolvedValueOnce('01FULL-PACK');
             ozonApiMethod
                 .mockResolvedValueOnce({
                     posting_number: 'P-1',
@@ -533,9 +534,56 @@ describe('PostingService', () => {
                     products: [
                         {
                             product_id: 999,
-                            quantity: 50,
+                            quantity: 1,
                             is_mandatory_mark_needed: true,
                             exemplars: [{ exemplar_id: 111, marks: [] }],
+                        },
+                    ],
+                })
+                .mockResolvedValueOnce({ result: { products: [{ offer_id: '531557', sku: 999 }] } })
+                .mockResolvedValueOnce(VALIDATE_OK)
+                .mockResolvedValueOnce({ result: true })
+                .mockResolvedValueOnce({ posting_number: 'P-1', status: 'ship_available', products: [] })
+                .mockResolvedValueOnce({ result: ['P-1'] });
+            const res = await service.submitFbsMarkCodes(invoice);
+            expect(res).toEqual({ ok: true, shipped: true });
+            expect(ozonApiMethod).toHaveBeenNthCalledWith(
+                4,
+                '/v6/fbs/posting/product/exemplar/set',
+                expect.objectContaining({
+                    products: [
+                        {
+                            product_id: 999,
+                            exemplars: [
+                                {
+                                    exemplar_id: 111,
+                                    marks: [{ mark: '01FULL-PACK', mark_type: 'mandatory_mark' }],
+                                    gtd: '',
+                                    is_gtd_absent: true,
+                                    is_rnpt_absent: true,
+                                },
+                            ],
+                        },
+                    ],
+                }),
+            );
+        });
+
+        it('число кодов ≠ числу экземпляров → failed', async () => {
+            getAttachedMarkCodesByScode.mockResolvedValueOnce([
+                { ki: 'KI-1', goodscode: '531557', realpricecode: 1, quantity: 3 },
+            ]);
+            getKmFullByKi.mockResolvedValueOnce('01FULL-1');
+            ozonApiMethod
+                .mockResolvedValueOnce({
+                    posting_number: 'P-1',
+                    multi_box_qty: 1,
+                    products: [
+                        {
+                            product_id: 999,
+                            quantity: 2,
+                            is_mandatory_mark_needed: true,
+                            exemplars: [{ exemplar_id: 111, marks: [] }, { exemplar_id: 112, marks: [] }],
                         },
                     ],
                 })
@@ -544,8 +592,7 @@ describe('PostingService', () => {
                 });
             const res = await service.submitFbsMarkCodes(invoice);
             expect(res.ok).toBe(false);
-            expect(res.failed[0].ki).toBe('KI-50');
-            expect(res.failed[0].reason).toContain('поделите код');
+            expect(res.failed[0].reason).toContain('привязано кодов 1');
         });
 
         it('createOrGet вернул пустой ответ → skipRetry=true', async () => {


### PR DESCRIPTION
…= 1 экземпляр

Ozon FBS принимает «один код с упаковки»: отправление на N упаковок = N экземпляров = N кодов (напр. арт. …-3: 2 юнита = 6 шт = 2 кода). Убран отказ на QUANTITY>1 и сверка суммы штук; теперь сверяем число кодов с числом экземпляров (group.length == exProduct.quantity), по одному коду в экземпляр.