### PR TITLE
fix(avito): avitoSku всегда возвращает строку

### DIFF
--- a/src/avito.card/avito.sku.spec.ts
+++ b/src/avito.card/avito.sku.spec.ts
@@ -1,0 +1,15 @@
+import { avitoSku } from './avito.sku';
+
+describe('avitoSku', () => {
+    it('всегда отдаёт строку — GOODSCODE в базе INTEGER, а DTO врёт про string', () => {
+        const sku = avitoSku({ goodsCode: 550539 as unknown as string, coeff: 1 });
+
+        expect(typeof sku).toBe('string');
+        expect(sku).toBe('550539');
+        expect(sku.includes('550539')).toBe(true); // именно это падало в MapSkusToGoodsCommand
+    });
+
+    it('к фасовке добавляет коэффициент', () => {
+        expect(avitoSku({ goodsCode: 550539 as unknown as string, coeff: 3 })).toBe('550539-3');
+    });
+});

--- a/src/avito.card/avito.sku.ts
+++ b/src/avito.card/avito.sku.ts
@@ -6,6 +6,9 @@ export const AVITO_MAX_QUANTITY = 999999;
 /**
  * Ключ товара для Авито: goodscode либо goodscode-коэффициент.
  * Единственная точка сборки — по этому ключу сходятся остатки и цены.
+ *
+ * String() обязателен: GOODSCODE в базе INTEGER, а DTO объявляет его строкой.
+ * Без приведения в skuList попадают числа, и MapSkusToGoodsCommand падает на sku.includes.
  */
 export const avitoSku = ({ goodsCode, coeff }: Pick<GoodAvitoDto, 'goodsCode' | 'coeff'>): string =>
-    coeff === 1 ? goodsCode : `${goodsCode}-${coeff}`;
+    coeff === 1 ? String(goodsCode) : `${goodsCode}-${coeff}`;


### PR DESCRIPTION
GOODSCODE в базе INTEGER, DTO объявляет его string. При coeff=1 avitoSku отдавал число как есть, оно уезжало в skuList, и MapSkusToGoodsCommand падал на sku.includes — обработчик counts.changed валился целиком, остатки не пушились. Прежний код собирал ключ шаблонной строкой и такого не допускал.